### PR TITLE
fix for #65: Unable to Open Console in LogViewer

### DIFF
--- a/de.anbos.eclipse.logviewer.plugin/src/de/anbos/eclipse/logviewer/plugin/file/ConsoleTail.java
+++ b/de.anbos.eclipse.logviewer.plugin/src/de/anbos/eclipse/logviewer/plugin/file/ConsoleTail.java
@@ -174,7 +174,7 @@ public class ConsoleTail implements IDocumentListener, Runnable {
 		IConsoleManager conMan = conPlugin.getConsoleManager();
 		IConsole[] existing = conMan.getConsoles();
 		for (int i = 0; i < existing.length; i++) {
-			if (name.equals(existing[i].getName())) {
+			if (existing[i].getName().contains(name)) {
 				return existing[i];
 			}
 		}


### PR DESCRIPTION
## Issue#65: Unable to Open Console in LogViewer
#

## Proposed changes
now we are looking for the existing console based on previously truncated console name

## Reviewers
@